### PR TITLE
Enable compression by adding GZipMiddleware

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -140,6 +140,7 @@ AUTH_PASSWORD_VALIDATORS = [
 # https://docs.djangoproject.com/en/dev/ref/settings/#middleware
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
+    "django.middleware.gzip.GZipMiddleware",
     "corsheaders.middleware.CorsMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",


### PR DESCRIPTION
Add middleware to allow for gzip compression, which is a particular improvement for serving dense map tiles to lower bandwidth devices